### PR TITLE
Add issue templates

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "tabWidth": 2,
+    "semi": false,
+    "singleQuote": true,
+    "proseWrap": "never"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Each organization has one code repository per project, except for most SDK repos
 
 ### Check first
 
-To save time and prevent duplicating work, it’s best to search the relevant project (repository) for open or closed issues or PRs related to your contribution. This is especially important for significant changes or enhancements.
+To save time and prevent duplicating work, it’s best to search the relevant project (repository) for open/closed issues or PRs related to your contribution. This is especially important for significant changes or enhancements.
 
 **You might also check in the [Kinde community](#community) to see if an issue has a discussion history.**
 
@@ -234,9 +234,9 @@ Join us in the [Slack](https://slack.com/intl/en-au) [Kinde community](https://j
 
 ### Where to post
 
-| Slack channel                                                                      | For                                  |
-| ---------------------------------------------------------------------------------- | ------------------------------------ |
-| [#requests-and-feedback](https://thekindecommunity.slack.com/archives/C04K34HUV9B) | Feature requests + product feedback  |
-| [#questions](https://thekindecommunity.slack.com/archives/C04KVMGSZLG)             | General questions                    |
-| [#kinde-support](https://thekindecommunity.slack.com/archives/C04K316BXEH)         | Support questions and reporting bugs |
-| [#documentation](https://thekindecommunity.slack.com/archives/C057M2BQ6LV)         | Reporting documentation issues       |
+| Slack channel | For |
+| --- | --- |
+| [#requests-and-feedback](https://thekindecommunity.slack.com/archives/C04K34HUV9B) | Feature requests + product feedback |
+| [#questions](https://thekindecommunity.slack.com/archives/C04KVMGSZLG) | General questions |
+| [#kinde-support](https://thekindecommunity.slack.com/archives/C04K316BXEH) | Support questions and reporting bugs |
+| [#documentation](https://thekindecommunity.slack.com/archives/C057M2BQ6LV) | Reporting documentation issues |

--- a/ISSUE_TEMPLATE/bug_report.yml
+++ b/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: '🐛 Bug report'
+description: Have you found a bug or issue in a Kinde library? Let us know here.
+title: 'Bug: (fill in)'
+labels: [bug]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report a bug 👍🏼.
+
+        Please fill out each section below, as it allows the core team to diagnose and hopefully fix your issue as quickly as possible.
+
+        **Please do not report security vulnerabilities here**. Refer to the [Kinde vulnerability disclosure policy](https://kinde.com/docs/important-information/vulnerability-disclosure-policy/).
+
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      description: To save time and prevent duplicating work, please complete the following.
+      options:
+        - label: I have searched the repository’s issues and [Kinde community](https://thekindecommunity.slack.com/archives/C04K316BXEH) to ensure my issue isn’t a duplicate
+          required: true
+        - label: I have checked the latest version of the library to replicate my issue
+          required: true
+        - label: I have read the [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md)
+          required: true
+        - label: I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CODE_OF_CONDUCT.md)
+          required: true
+
+  - type: textarea
+    attributes:
+      label: Describe the issue
+      description: Provide a summary of the issue and what you expected to happen, including specific steps to reproduce.
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Library URL
+      description: The library’s repository URL, e.g., “https://github.com/kinde-oss/kinde-auth-react”.
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Library version
+      description: The library’s version number, e.g., “3.0.15”.
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Operating system(s)
+      description: What operating system(s) are you using?
+      options:
+        - Windows
+        - macOS
+        - Android
+        - iOS
+        - Ubuntu
+        - Other Linux
+        - Other (see “Further environment details”)
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Operating system version(s)
+      description: What operating system version(s) are you using? E.g. “Windows 10 version 1909”, “macOS Catalina 10.15.7”, “Ubuntu 20.04”, etc.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Further environment details
+      description: Any further environment details you think are relevant and helpful for the core team to know. E.g., your browser name and version, e.g., “Chrome v102”, “Firefox v98”. Your technology/framework name and version, e.g., “Node.js v20.2.0”, “Next.js v13.4.2”, etc. Other operating systems not listed above.
+
+  - type: input
+    attributes:
+      label: Reproducible test case URL
+      description: The URL for a standalone test case - a minimal reproduction of the problem. It could be a link to a code playground like [StackBlitz](https://stackblitz.com/), [JSFiddle](https://jsfiddle.net/), [CodeSandbox](https://codesandbox.io/), or a GitHub repo. A minimal reproduction is desirable so others can help debug your issue and is **the best way** to ensure it gets triaged quickly by the core team.
+
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Is there anything else that’s important for the core team to know?

--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: '🙋🏽‍♀️ Questions and help'
+    url: https://thekindecommunity.slack.com
+    about: For any questions, discussions, or general help, please ask in the Kinde community.
+  - name: '📖 SDK documentation'
+    url: https://kinde.com/docs
+    about: View the documentation for all of the Kinde SDKs.
+  - name: '🚨 Security vulnerability'
+    url: https://kinde.com/docs/important-information/vulnerability-disclosure-policy
+    about: Privately report a security vulnerability.

--- a/ISSUE_TEMPLATE/documentation_issue.yml
+++ b/ISSUE_TEMPLATE/documentation_issue.yml
@@ -1,0 +1,38 @@
+name: '📖 Documentation issue'
+description: Have you found a mistake in the [Kinde SDK documentation](https://kinde.com/docs/developer-tools), or have a suggestion to improve them? Let us know here.
+title: 'Documentation issue: (fill in)'
+labels: [documentation]
+
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for taking the time to report a documentation issue 👍🏼.
+
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      description: To save time and prevent duplicating work, please complete the following.
+      options:
+        - label: I have searched the repository’s issues and the [Kinde community](https://thekindecommunity.slack.com/archives/C057M2BQ6LV) to ensure my documentation issue isn’t a duplicate
+          required: true
+        - label: I have read the [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md)
+          required: true
+        - label: I agree to the terms in the [code of conduct](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CODE_OF_CONDUCT.md)
+          required: true
+
+  - type: textarea
+    attributes:
+      label: What is the improvement or update you wish to see?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Is there any context that might help us understand?
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Document URL
+      description: If the document already exists, please include its URL. E.g. “https://kinde.com/docs/developer-tools/javascript-sdk”.

--- a/ISSUE_TEMPLATE/feature_request.yml
+++ b/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: '💡 Feature request'
+description: Would you like to see a new capability in a Kinde library? Let us know here.
+title: 'Feature request: (fill in)'
+labels: [enhancement]
+
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for taking the time to request a feature 👍🏼.
+
+  - type: checkboxes
+    attributes:
+      label: Prerequisites
+      description: To save time and prevent duplicating work, please complete the following.
+      options:
+        - label: I have searched the repository’s issues and [Kinde community](https://thekindecommunity.slack.com/archives/C04K34HUV9B) to ensure my feature request isn’t a duplicate
+          required: true
+        - label: I have read the [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md)
+          required: true
+        - label: I agree to the terms in the [code of conduct](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CODE_OF_CONDUCT.md)
+          required: true
+
+  - type: textarea
+    attributes:
+      label: What is the problem you’re trying to solve?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: What solution would you like to see?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Is there anything else that’s important for the core team to know?

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Community health files for SDK libraries
+
+All the default [GitHub community health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) for all SDK repositories, including [issue and PR templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates).

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,6 @@
 # Hi there 👋
 
-Here you'll find SDKs and libraries for a bunch of different technologies to work with the Kinde ecosystem.
+Here you’ll find SDKs and libraries for a bunch of different technologies to work with the Kinde ecosystem.
 
 If you have an existing project, this is a great place to get started.
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -4,6 +4,6 @@ Here you'll find SDKs and libraries for a bunch of different technologies to wor
 
 If you have an existing project, this is a great place to get started.
 
-Instructions on how to get up and going exist in the relevant repo’s README, or you can read the [Kinde documentation](https://kinde.com/docs). For contributing guidelines, see the [CONTRIBUTING.md](../CONTRIBUTING.md) doc.
+Instructions on how to get up and going exist in the relevant repo’s README, or you can read the [Kinde documentation](https://kinde.com/docs). For contributing guidelines, see the [CONTRIBUTING.md](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md) doc.
 
 Consider using one of our [Kinde starter kits](https://github.com/kinde-starter-kits) if you're starting from scratch.


### PR DESCRIPTION
Added [issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates) for the following:

* Bug report
* Feature request
* Documentation issue

Plus:

* Configure the issue template selector via `config.yml`.
* Add a README for this repo.