### PR TITLE
Update the contributing doc to include a “New repositories" section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @daveordead @chris-pearce

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -2,128 +2,79 @@
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, caste, color, religion, or sexual
-identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
 
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to a positive environment for our
-community include:
+Examples of behavior that contributes to a positive environment for our community include:
 
 - Demonstrating empathy and kindness toward other people
 - Being respectful of differing opinions, viewpoints, and experiences
 - Giving and gracefully accepting constructive feedback
-- Accepting responsibility and apologizing to those affected by our mistakes,
-  and learning from the experience
-- Focusing on what is best not just for us as individuals, but for the overall
-  community
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
 
 Examples of unacceptable behavior include:
 
-- The use of sexualized language or imagery, and sexual attention or advances of
-  any kind
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
 - Trolling, insulting or derogatory comments, and personal or political attacks
 - Public or private harassment
-- Publishing others' private information, such as a physical or email address,
-  without their explicit permission
-- Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
-or harmful.
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
-Community leaders have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned to this Code of Conduct, and will communicate reasons for moderation
-decisions when appropriate.
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
-posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-support@kinde.com.
-All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at support@kinde.com. All complaints will be reviewed and investigated promptly and fairly.
 
-All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
 ## Enforcement Guidelines
 
-Community leaders will follow these Community Impact Guidelines in determining
-the consequences for any action they deem in violation of this Code of Conduct:
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
 
 ### 1. Correction
 
-**Community Impact**: Use of inappropriate language or other behavior deemed
-unprofessional or unwelcome in the community.
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
 
-**Consequence**: A private, written warning from community leaders, providing
-clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
-**Community Impact**: A violation through a single incident or series of
-actions.
+**Community Impact**: A violation through a single incident or series of actions.
 
-**Consequence**: A warning with consequences for continued behavior. No
-interaction with the people involved, including unsolicited interaction with
-those enforcing the Code of Conduct, for a specified period of time. This
-includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or permanent
-ban.
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
 
 ### 3. Temporary Ban
 
-**Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
 
-**Consequence**: A temporary ban from any sort of interaction or public
-communication with the community for a specified period of time. No public or
-private interaction with the people involved, including unsolicited interaction
-with those enforcing the Code of Conduct, is allowed during this period.
-Violating these terms may lead to a permanent ban.
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent Ban
 
-**Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior, harassment of an
-individual, or aggression toward or disparagement of classes of individuals.
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within the
-community.
+**Consequence**: A permanent ban from any sort of public interaction within the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.1, available at
-[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
 
-Community Impact Guidelines were inspired by
-[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
 
-For answers to common questions about this code of conduct, see the FAQ at
-[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
-[https://www.contributor-covenant.org/translations][translations].
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
 
 [homepage]: https://www.contributor-covenant.org
 [v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,6 +25,9 @@
   - [Creating a PR](#creating-a-pr)
   - [Guidelines](#guidelines-1)
   - [Your PR merges!](#your-pr-merges)
+- [New repositories](#new-repositories)
+  - [READMEs](#readmes)
+  - [Community health files](#community-health-files)
 - [SDKs](#sdks)
   - [Mustache templates](#mustache-templates)
     - [TypeScript example](#typescript-example)
@@ -164,6 +167,20 @@ Awesome! Thanks so much for contributing to a Kinde OS project.
 
 Once your PR merges, your contributions are publicly visible in the relevant project and will be reflected in the project’s changelog.
 
+## New repositories
+
+Please always create new repositories from the relevant template to ensure consistency across Kinde repositories.
+
+When you create a new repository, GitHub will provide a list of available templates. For example, when you create a new [SDK](#sdks) repository, choose the `kinde-oss-repo-template` template. Once the new repository gets created, complete the checklist in the `_NEW_REPO_CHECKLIST_.md` file.
+
+### READMEs
+
+Please follow the README template to avoid duplicating documentation between the [Kinde docs](https://kinde.com/docs/) and a project’s README and to keep Kinde READMEs consistent.
+
+### Community health files
+
+Please refrain from adding [community health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file), e.g. `CONTRIBUTING.md`, `SECURITY.md`, etc. (any of the files listed [here](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file#supported-file-types)) to the repository’s `.github` folder as Kinde houses these globally in the GitHub organization `.github` repository to avoid duplication and ease of maintenance. If a community health file gets added to a repository, it will override the global health files, which we want to avoid.
+
 ## SDKs
 
 Most of Kinde’s OS projects are comprised of software development kits (SDKs) that are generated using the [OpenAPI Generator tool](https://openapi-generator.tech/). As a result, each SDK has two repositories: one for the generator and one for the end code. For example, the Ruby SDK has the following repositories:
@@ -206,7 +223,7 @@ export * from './client/client'; /* This line was added */
 
 ## Documentation
 
-To avoid duplicating documentation between the [Kinde docs](https://kinde.com/docs/) and a project’s README, we prefer to link to the Kinde docs when possible.
+To avoid duplicating documentation between the [Kinde docs](https://kinde.com/docs/) and a project’s README, Kinde prefers to link to the Kinde docs when possible.
 
 If you encounter problems with the [Kinde docs](https://kinde.com/docs/), believe something is missing or unclear, or spot a typo, please submit an [issue](#issues) via the “Documentation issues” template.
 
@@ -228,9 +245,9 @@ By contributing to Kinde, you agree that your contributions will be licensed und
 
 ## Community
 
-Join us in the Slack [Kinde community](https://thekindecommunity.slack.com) and post your questions there. A friendly Kinde staff member is always happy to help, and it might save you a lot of time.
+Join us in the Slack [Kinde community](https://thekindecommunity.slack.com) and post your questions there. The whole Kinde team is on hand to help you out.
 
-**Note:** please submit your general or support-related questions in the Kinde community rather than on GitHub.
+**Note:** Please submit your general or support-related questions in the Kinde community rather than on GitHub.
 
 ### Where to post
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
   <a href="https://kinde.com" target="_blank" rel="noopener noreferrer">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="kinde_logo_dark.jpg">
-      <img src="kinde_logo_light.jpg" height="100">
+      <img src="../kinde_logo_light.jpg" height="100">
     </picture>
   </a>
 </p>
@@ -28,6 +28,7 @@
 - [New repositories](#new-repositories)
   - [READMEs](#readmes)
   - [Community health files](#community-health-files)
+  - [SDK repository name](#sdk-repository-name)
 - [SDKs](#sdks)
   - [Mustache templates](#mustache-templates)
     - [TypeScript example](#typescript-example)
@@ -179,7 +180,11 @@ Please follow the README template to avoid duplicating documentation between the
 
 ### Community health files
 
-Please refrain from adding [community health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file), e.g. `CONTRIBUTING.md`, `SECURITY.md`, etc. (any of the files listed [here](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file#supported-file-types)) to the repository’s `.github` folder as Kinde houses these globally in the GitHub organization `.github` repository to avoid duplication and ease of maintenance. If a community health file gets added to a repository, it will override the global health files, which we want to avoid.
+Please refrain from adding [community health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file), e.g. `CONTRIBUTING.md`, `SECURITY.md`, etc. (any of the files listed [here](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file#supported-file-types)) to the repository’s `.github` folder (or in the root or `docs` folder) as Kinde houses these globally in the GitHub organization `.github` repository to avoid duplication and ease of maintenance. If a community health file gets added to a repository, it will override the global health files, which we want to avoid.
+
+### SDK repository name
+
+For the name of an SDK repository, please use the following format: `kinde-[technology/framework name]`, e.g. `kinde-react` or `kinde-elixir`. For generator repositories (see [SDKs](#sdkds) to learn more), add “generator” at the end, e.g. `kinde-react-generator` or `kinde-elixir-generator`.
 
 ## SDKs
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,7 +2,7 @@
   <a href="https://kinde.com" target="_blank" rel="noopener noreferrer">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="kinde_logo_dark.jpg">
-      <img src="kinde_logo_light.jpg" height="100">
+      <img src="../kinde_logo_light.jpg" height="100">
     </picture>
   </a>
 </p>

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,5 @@
 {
-    "tabWidth": 2,
-    "semi": false,
-    "singleQuote": true,
-    "proseWrap": "never"
+  "semi": false,
+  "singleQuote": true,
+  "proseWrap": "never"
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,8 @@
 {
-  "recommendations": ["yzhang.markdown-all-in-one"]
+  "recommendations": [
+    "yzhang.markdown-all-in-one",
+    "editorconfig.editorconfig",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode"
+  ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
   "recommendations": [
     "yzhang.markdown-all-in-one",
     "editorconfig.editorconfig",
-    "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode"
   ]
 }


### PR DESCRIPTION
# Explain your changes

Update the contributing doc to include a “New repositories" section, which got prompted from working on the "repo template". 

## Other

- `CODE_OF_CONDUCT.md` shows changes as the Prettier config update affected it.
- Add a `CODEOWNERS` file. I added myself so I can get flagged on changes for this repo. FYI: This file doesn't get applied to repos under the `kinde-oss` org like the other health files.
- Add more recommended VSC extensions.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
