### PR TITLE
Fix links to the community health docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,9 +22,9 @@ body:
           required: true
         - label: I have checked the latest version of the library to replicate my issue
           required: true
-        - label: I have read the [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md)
+        - label: I have read the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md)
           required: true
-        - label: I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CODE_OF_CONDUCT.md)
+        - label: I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md)
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/documentation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.yml
@@ -15,9 +15,9 @@ body:
       options:
         - label: I have searched the repository’s issues and the [Kinde community](https://thekindecommunity.slack.com/archives/C057M2BQ6LV) to ensure my documentation issue isn’t a duplicate
           required: true
-        - label: I have read the [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md)
+        - label: I have read the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md)
           required: true
-        - label: I agree to the terms in the [code of conduct](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CODE_OF_CONDUCT.md)
+        - label: I agree to the terms in the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md)
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -15,9 +15,9 @@ body:
       options:
         - label: I have searched the repository’s issues and [Kinde community](https://thekindecommunity.slack.com/archives/C04K34HUV9B) to ensure my feature request isn’t a duplicate
           required: true
-        - label: I have read the [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md)
+        - label: I have read the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md)
           required: true
-        - label: I agree to the terms in the [code of conduct](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CODE_OF_CONDUCT.md)
+        - label: I agree to the terms in the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md)
           required: true
 
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ _Suppose there is a related issue with enough detail for a reviewer to understan
 
 # Checklist
 
-- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md).
-- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CODE_OF_CONDUCT.md).
+- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
+- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).
 
 🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._

--- a/profile/README.md
+++ b/profile/README.md
@@ -4,6 +4,6 @@ Here you’ll find SDKs and libraries for a bunch of different technologies to w
 
 If you have an existing project, this is a great place to get started.
 
-Instructions on how to get up and going exist in the relevant repo’s README, or you can read the [Kinde documentation](https://kinde.com/docs). For contributing guidelines, see the [CONTRIBUTING.md](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md) doc.
+Instructions on how to get up and going exist in the relevant repo’s README, or you can read the [Kinde documentation](https://kinde.com/docs). For contributing guidelines, see the [Contributing doc](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
 
 Consider using one of our [Kinde starter kits](https://github.com/kinde-starter-kits) if you're starting from scratch.


### PR DESCRIPTION
# Explain your changes

The links to the community health docs weren't pointing to the `main` branch. This PR rectifies that.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
