### PR TITLE
Updating links and mentioning the public roadmap

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
   <a href="https://kinde.com" target="_blank" rel="noopener noreferrer">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="kinde_logo_dark.jpg">
-      <img src="../kinde_logo_light.jpg" height="100">
+      <img src="https://raw.githubusercontent.com/kinde-oss/.github/main/kinde_logo_light.jpg" height="100">
     </picture>
   </a>
 </p>
@@ -80,7 +80,7 @@ Each organization has one code repository per project, except for most SDK repos
 
 To save time and prevent duplicating work, it’s best to search the relevant project (repository) for open/closed issues or PRs related to your contribution. This is especially important for significant changes or enhancements.
 
-**You might also check in the [Kinde community](#community) to see if an issue has a discussion history.**
+**You might also check in the [Kinde community](#community) to see if an issue has a discussion history or the [public roadmap](https://updates.kinde.com/board) for planned enhancements.**
 
 ### First time
 
@@ -101,7 +101,7 @@ Issues is where everything gets logged against a project, including:
 - Bug reports
 - Documentation issues
 
-Issues should be the first port of call alongside the [Kinde community](#community) when considering contributing to a Kinde OS project.
+Issues should be the first port of call alongside the [Kinde community](#community) and [public roadmap](https://updates.kinde.com/board) when considering contributing to a Kinde OS project.
 
 🎓 You can read more about issues in [GitHub Docs](https://docs.github.com/en) → [GitHub Issues](https://docs.github.com/en/issues).
 
@@ -240,7 +240,7 @@ If you discover a security vulnerability in a Kinde OS project, please report it
 
 ## Publishing
 
-The core team is in charge of handling version updates and publishing. We’re currently working on updating the documentation for this, and it should be available soon.
+The core team is in charge of handling version updates and publishing. Typically, the publishing instructions will be in the repository's README.
 
 Kinde OS projects adhere to the [Semantic Versioning standard](https://semver.org/), and we strive to ensure that changelogs are available for each project.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,7 +18,7 @@ body:
       label: Prerequisites
       description: To save time and prevent duplicating work, please complete the following.
       options:
-        - label: I have searched the repository’s issues, [Kinde community](https://thekindecommunity.slack.com/archives/C04K34HUV9B) and [public roadmap](https://updates.kinde.com/board) to ensure my feature request isn’t a duplicate
+        - label: I have searched the repository’s issues and [Kinde community](https://thekindecommunity.slack.com/archives/C04K316BXEH) to ensure my issue isn’t a duplicate
           required: true
         - label: I have checked the latest version of the library to replicate my issue
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,13 +18,13 @@ body:
       label: Prerequisites
       description: To save time and prevent duplicating work, please complete the following.
       options:
-        - label: I have searched the repository’s issues and [Kinde community](https://thekindecommunity.slack.com/archives/C04K316BXEH) to ensure my issue isn’t a duplicate
+        - label: I have searched the repository’s issues, [Kinde community](https://thekindecommunity.slack.com/archives/C04K34HUV9B) and [public roadmap](https://updates.kinde.com/board) to ensure my feature request isn’t a duplicate
           required: true
         - label: I have checked the latest version of the library to replicate my issue
           required: true
-        - label: I have read the [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md)
+        - label: I have read the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md)
           required: true
-        - label: I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CODE_OF_CONDUCT.md)
+        - label: I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md)
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/documentation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.yml
@@ -13,11 +13,11 @@ body:
       label: Prerequisites
       description: To save time and prevent duplicating work, please complete the following.
       options:
-        - label: I have searched the repository’s issues and the [Kinde community](https://thekindecommunity.slack.com/archives/C057M2BQ6LV) to ensure my documentation issue isn’t a duplicate
+        - label: I have searched the repository’s issues, [Kinde community](https://thekindecommunity.slack.com/archives/C04K34HUV9B) and [public roadmap](https://updates.kinde.com/board) to ensure my feature request isn’t a duplicate
           required: true
-        - label: I have read the [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md)
+        - label: I have read the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md)
           required: true
-        - label: I agree to the terms in the [code of conduct](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CODE_OF_CONDUCT.md)
+        - label: I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md)
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/documentation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.yml
@@ -13,7 +13,7 @@ body:
       label: Prerequisites
       description: To save time and prevent duplicating work, please complete the following.
       options:
-        - label: I have searched the repository’s issues, [Kinde community](https://thekindecommunity.slack.com/archives/C04K34HUV9B) and [public roadmap](https://updates.kinde.com/board) to ensure my feature request isn’t a duplicate
+        - label: I have searched the repository’s issues and the [Kinde community](https://thekindecommunity.slack.com/archives/C057M2BQ6LV) to ensure my documentation issue isn’t a duplicate
           required: true
         - label: I have read the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md)
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,18 +6,18 @@ labels: [enhancement]
 body:
   - type: markdown
     attributes:
-      value: Thank you for taking the time to request a new feature 👍🏼.
+      value: Thank you for taking the time to request a new feature 👍🏼. Be sure to check the [public roadmap](https://updates.kinde.com/board), as we could be about to start work on it, or it's pegged for the future.
 
   - type: checkboxes
     attributes:
       label: Prerequisites
       description: To save time and prevent duplicating work, please complete the following.
       options:
-        - label: I have searched the repository’s issues and [Kinde community](https://thekindecommunity.slack.com/archives/C04K34HUV9B) to ensure my feature request isn’t a duplicate
+        - label: I have searched the repository’s issues, [Kinde community](https://thekindecommunity.slack.com/archives/C04K34HUV9B) and [public roadmap](https://updates.kinde.com/board) to ensure my feature request isn’t a duplicate
           required: true
-        - label: I have read the [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md)
+        - label: I have read the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md)
           required: true
-        - label: I agree to the terms in the [code of conduct](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CODE_OF_CONDUCT.md)
+        - label: I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md)
           required: true
 
   - type: textarea

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ _Suppose there is a related issue with enough detail for a reviewer to understan
 
 # Checklist
 
-- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md).
-- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CODE_OF_CONDUCT.md).
+- [ ] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/main/.github/CONTRIBUTING.md).
+- [ ] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/main/.github/CODE_OF_CONDUCT.md).
 
 🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,7 +2,7 @@
   <a href="https://kinde.com" target="_blank" rel="noopener noreferrer">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="kinde_logo_dark.jpg">
-      <img src="../kinde_logo_light.jpg" height="100">
+      <img src="https://raw.githubusercontent.com/kinde-oss/.github/main/kinde_logo_light.jpg" height="100">
     </picture>
   </a>
 </p>

--- a/profile/README.md
+++ b/profile/README.md
@@ -4,6 +4,6 @@ Here you’ll find SDKs and libraries for a bunch of different technologies to w
 
 If you have an existing project, this is a great place to get started.
 
-Instructions on how to get up and going exist in the relevant repo’s README, or you can read the [Kinde documentation](https://kinde.com/docs). For contributing guidelines, see the [CONTRIBUTING.md](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md) doc.
+Instructions on how to get up and going exist in the relevant repo’s README, or you can read the [Kinde documentation](https://kinde.com/docs). For contributing guidelines, see [here](../.github/CONTRIBUTING.md).
 
-Consider using one of our [Kinde starter kits](https://github.com/kinde-starter-kits) if you're starting from scratch.
+Consider using one of our [Kinde starter kits](https://github.com/kinde-starter-kits) if you’re starting from scratch.


### PR DESCRIPTION
# Explain your changes

- Ensure all links point to the `main` branch.
- Make the logo URL absolute so it renders when linked from `kinde-oss` repos.
- Mention the public roadmap where applicable.
- Update the "Publishing" section in the contributing doc.

# Checklist

- [x] I have read the [“Pull requests” section](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md#pull-requests) in the [contributing guidelines](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CONTRIBUTING.md).
- [x] I agree to the terms within the [code of conduct](https://github.com/kinde-oss/.github/blob/489e2ca9c3307c2b2e098a885e22f2239116394a/CODE_OF_CONDUCT.md).

🛟 _If you need help, consider asking for advice over in the [Kinde community](https://thekindecommunity.slack.com)._
